### PR TITLE
Add GitHub-authenticated gallery management interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ npm run dev
 
 Open [http://localhost:3002](http://localhost:3002) with your browser to see the result.
 
+## Configuration
+
+Authentication and gallery management rely on the following environment variables:
+
+- `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` – OAuth credentials for GitHub sign-in.
+- `NEXTAUTH_SECRET` – Secret used by NextAuth.js to encrypt session data.
+- `S3_GALLERIES_BUCKET` – S3 bucket that stores gallery metadata (each gallery record is persisted as JSON).
+
+Set these variables in your preferred `.env.local` file before starting the development server to unlock the gallery management experience.
+
 ## Tech Stack
 
 - Next.js 15
@@ -33,6 +43,7 @@ Open [http://localhost:3002](http://localhost:3002) with your browser to see the
 - **PR & Release Comparison**: Visual comparison of pull requests and releases
 - **City Planning View**: Alternative architectural visualization
 - **Gallery**: Browse and explore multiple repositories
+- **Gallery Management**: Create and configure hackathon galleries with GitHub authentication and S3-backed storage
 - **Color Palette**: Customizable file type color schemes
 
 ## Project Structure

--- a/src/app/api/galleries/[galleryId]/route.ts
+++ b/src/app/api/galleries/[galleryId]/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { z } from "zod";
+
+import { authOptions } from "@/lib/auth";
+import { getGalleryStore } from "@/services/s3/gallery-store";
+import {
+  GalleryNotFoundError,
+  MissingGalleryBucketError,
+} from "@/types/gallery";
+
+const updateGallerySchema = z.object({
+  name: z.string().min(1).optional(),
+  description: z.string().max(2000).optional(),
+  allowPublicSubmissions: z.boolean().optional(),
+});
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: { galleryId: string } },
+) {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    return NextResponse.json(
+      { error: "Authentication required" },
+      { status: 401 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  const parsed = updateGallerySchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten().formErrors.join(", ") },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const store = getGalleryStore();
+    const gallery = await store.updateGallery(params.galleryId, parsed.data);
+    return NextResponse.json({ gallery });
+  } catch (error) {
+    if (error instanceof GalleryNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+
+    if (error instanceof MissingGalleryBucketError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 500 },
+      );
+    }
+
+    console.error("Error updating gallery", error);
+    return NextResponse.json(
+      { error: "Failed to update gallery" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/galleries/route.ts
+++ b/src/app/api/galleries/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import { getGalleryStore } from "@/services/s3/gallery-store";
+import { MissingGalleryBucketError } from "@/types/gallery";
+
+const createGallerySchema = z.object({
+  name: z.string().min(1, "Gallery name is required"),
+  description: z
+    .string()
+    .max(2000, "Description must be 2000 characters or less")
+    .optional(),
+  allowPublicSubmissions: z.boolean().default(false),
+});
+
+export async function GET() {
+  try {
+    const store = getGalleryStore();
+    const galleries = await store.listGalleries();
+    return NextResponse.json({ galleries });
+  } catch (error) {
+    if (error instanceof MissingGalleryBucketError) {
+      return NextResponse.json(
+        { error: error.message, galleries: [] },
+        { status: 200 },
+      );
+    }
+
+    console.error("Error fetching galleries", error);
+    return NextResponse.json(
+      { error: "Failed to load galleries" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    return NextResponse.json(
+      { error: "Authentication required" },
+      { status: 401 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  const parsed = createGallerySchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten().formErrors.join(", ") },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const store = getGalleryStore();
+    const gallery = await store.createGallery({
+      ...parsed.data,
+      allowPublicSubmissions:
+        parsed.data.allowPublicSubmissions ?? false,
+      createdBy: session.user?.name || session.user?.login || "Unknown",
+      createdById: session.user?.id || "",
+      createdByLogin: session.user?.login || "",
+    });
+
+    return NextResponse.json({ gallery }, { status: 201 });
+  } catch (error) {
+    if (error instanceof MissingGalleryBucketError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 500 },
+      );
+    }
+
+    console.error("Error creating gallery", error);
+    return NextResponse.json(
+      { error: "Failed to create gallery" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -56,15 +56,14 @@ export default function RootLayout({
       <body
         className={`${inter.variable} ${firaCode.variable} antialiased h-full`}
       >
-        {/* Temporarily disabled auth - uncomment when you need authentication */}
-        {/* <AuthSessionProvider>
-          <AuthRefreshProvider> */}
-        <ClientThemeProvider>
-          <MermaidInitializer />
-          {children}
-        </ClientThemeProvider>
-        {/* </AuthRefreshProvider>
-        </AuthSessionProvider> */}
+        <AuthSessionProvider>
+          <AuthRefreshProvider>
+            <ClientThemeProvider>
+              <MermaidInitializer />
+              {children}
+            </ClientThemeProvider>
+          </AuthRefreshProvider>
+        </AuthSessionProvider>
       </body>
     </html>
   );

--- a/src/app/manage/galleries/page.tsx
+++ b/src/app/manage/galleries/page.tsx
@@ -1,0 +1,49 @@
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import GalleryManager from "@/components/gallery/GalleryManager";
+import GallerySignInPrompt from "@/components/gallery/GallerySignInPrompt";
+import { getGalleryStore } from "@/services/s3/gallery-store";
+import {
+  MissingGalleryBucketError,
+  type GalleryRecord,
+} from "@/types/gallery";
+
+export const dynamic = "force-dynamic";
+
+export default async function ManageGalleriesPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    return (
+      <main className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 text-white flex items-center justify-center p-6">
+        <GallerySignInPrompt />
+      </main>
+    );
+  }
+
+  let initialGalleries: GalleryRecord[] = [];
+  let initialError: string | null = null;
+
+  try {
+    const store = getGalleryStore();
+    initialGalleries = await store.listGalleries();
+  } catch (error) {
+    if (error instanceof MissingGalleryBucketError) {
+      initialError = error.message;
+    } else {
+      console.error("Failed to load galleries", error);
+      initialError = "We couldn't load galleries. Please try again.";
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 text-white p-6 pb-20">
+      <GalleryManager
+        initialGalleries={initialGalleries}
+        initialError={initialError}
+        currentUserLogin={session.user?.login || session.user?.email || "you"}
+      />
+    </main>
+  );
+}

--- a/src/components/gallery/GalleryManager.tsx
+++ b/src/components/gallery/GalleryManager.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+import type { GalleryRecord } from "@/types/gallery";
+
+interface GalleryManagerProps {
+  initialGalleries: GalleryRecord[];
+  initialError?: string | null;
+  currentUserLogin: string;
+}
+
+interface CreateGalleryFormState {
+  name: string;
+  description: string;
+  allowPublicSubmissions: boolean;
+}
+
+export default function GalleryManager({
+  initialGalleries,
+  initialError,
+  currentUserLogin,
+}: GalleryManagerProps) {
+  const [galleries, setGalleries] = useState<GalleryRecord[]>(
+    initialGalleries,
+  );
+  const [formState, setFormState] = useState<CreateGalleryFormState>({
+    name: "",
+    description: "",
+    allowPublicSubmissions: false,
+  });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(
+    initialError || null,
+  );
+  const [updatingGalleryId, setUpdatingGalleryId] = useState<string | null>(
+    null,
+  );
+
+  const resetMessages = () => {
+    setErrorMessage(null);
+    setActionMessage(null);
+  };
+
+  const handleCreateGallery = async (event: FormEvent) => {
+    event.preventDefault();
+    resetMessages();
+
+    if (!formState.name.trim()) {
+      setErrorMessage("Gallery name is required");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const response = await fetch("/api/galleries", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          name: formState.name.trim(),
+          description: formState.description.trim() || undefined,
+          allowPublicSubmissions: formState.allowPublicSubmissions,
+        }),
+      });
+
+      const data = (await response.json().catch(() => null)) as
+        | { gallery: GalleryRecord; error?: string }
+        | null;
+
+      if (!response.ok || !data?.gallery) {
+        throw new Error(data?.error || "Failed to create gallery");
+      }
+
+      setGalleries((current) => [data.gallery, ...current]);
+      setFormState({ name: "", description: "", allowPublicSubmissions: false });
+      setActionMessage(`Gallery “${data.gallery.name}” created successfully`);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleTogglePublicSubmissions = async (
+    galleryId: string,
+    allowPublicSubmissions: boolean,
+  ) => {
+    resetMessages();
+    setUpdatingGalleryId(galleryId);
+
+    try {
+      const response = await fetch(`/api/galleries/${galleryId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ allowPublicSubmissions }),
+      });
+
+      const data = (await response.json().catch(() => null)) as
+        | { gallery: GalleryRecord; error?: string }
+        | null;
+
+      if (!response.ok || !data?.gallery) {
+        throw new Error(data?.error || "Failed to update gallery");
+      }
+
+      setGalleries((current) =>
+        current.map((gallery) =>
+          gallery.id === galleryId ? data.gallery : gallery,
+        ),
+      );
+      setActionMessage(
+        allowPublicSubmissions
+          ? "Gallery is now open for public submissions"
+          : "Gallery submissions are limited to organizers",
+      );
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setUpdatingGalleryId(null);
+    }
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-10">
+      <header className="space-y-2">
+        <h1 className="text-4xl font-semibold text-white">Gallery manager</h1>
+        <p className="text-gray-300">
+          Signed in as <span className="font-medium">{currentUserLogin}</span>.
+          Create hackathon galleries and control whether anyone can add
+          repositories.
+        </p>
+      </header>
+
+      <section className="p-8 border border-gray-800 bg-gray-900/70 rounded-2xl shadow-lg">
+        <h2 className="text-2xl font-semibold text-white mb-4">
+          Create a new gallery
+        </h2>
+        <form className="space-y-6" onSubmit={handleCreateGallery}>
+          <div className="space-y-2 text-left">
+            <label className="block text-sm font-medium text-gray-200">
+              Gallery name
+            </label>
+            <input
+              type="text"
+              value={formState.name}
+              onChange={(event) =>
+                setFormState((current) => ({
+                  ...current,
+                  name: event.target.value,
+                }))
+              }
+              className="w-full rounded-lg border border-gray-700 bg-gray-950 px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="e.g. Winter Hackathon 2025"
+            />
+          </div>
+
+          <div className="space-y-2 text-left">
+            <label className="block text-sm font-medium text-gray-200">
+              Description (optional)
+            </label>
+            <textarea
+              value={formState.description}
+              onChange={(event) =>
+                setFormState((current) => ({
+                  ...current,
+                  description: event.target.value,
+                }))
+              }
+              className="w-full rounded-lg border border-gray-700 bg-gray-950 px-4 py-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              rows={3}
+              placeholder="Share context for participants about this gallery"
+            />
+          </div>
+
+          <label className="flex items-center gap-3 text-left">
+            <input
+              type="checkbox"
+              checked={formState.allowPublicSubmissions}
+              onChange={(event) =>
+                setFormState((current) => ({
+                  ...current,
+                  allowPublicSubmissions: event.target.checked,
+                }))
+              }
+              className="h-5 w-5 rounded border-gray-700 bg-gray-950 text-blue-500 focus:ring-blue-500"
+            />
+            <span className="text-gray-200">
+              Allow anyone with the link to add repositories to this gallery
+            </span>
+          </label>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 hover:bg-blue-500 disabled:opacity-60 px-5 py-2 text-white font-medium transition"
+          >
+            {isSubmitting ? "Creating…" : "Create gallery"}
+          </button>
+        </form>
+      </section>
+
+      {(errorMessage || actionMessage) && (
+        <div
+          className={`rounded-xl border px-4 py-3 text-sm font-medium ${
+            errorMessage
+              ? "border-red-500 bg-red-900/30 text-red-200"
+              : "border-emerald-500 bg-emerald-900/30 text-emerald-200"
+          }`}
+        >
+          {errorMessage || actionMessage}
+        </div>
+      )}
+
+      <section className="space-y-6">
+        <h2 className="text-2xl font-semibold text-white">
+          Existing galleries
+        </h2>
+
+        {galleries.length === 0 ? (
+          <p className="text-gray-400">
+            No galleries yet. Create one above to get started.
+          </p>
+        ) : (
+          <ul className="space-y-4">
+            {galleries.map((gallery) => (
+              <li
+                key={gallery.id}
+                className="border border-gray-800 bg-gray-900/60 rounded-2xl p-6"
+              >
+                <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                  <div className="space-y-2">
+                    <div className="flex flex-wrap items-center gap-3">
+                      <h3 className="text-xl font-semibold text-white">
+                        {gallery.name}
+                      </h3>
+                      <span className="rounded-full bg-gray-800 px-3 py-1 text-xs font-medium text-gray-300">
+                        Created {new Date(gallery.createdAt).toLocaleString()}
+                      </span>
+                    </div>
+                    {gallery.description && (
+                      <p className="text-gray-300 max-w-3xl">
+                        {gallery.description}
+                      </p>
+                    )}
+                    <p className="text-sm text-gray-400">
+                      Owner: {gallery.createdBy || "Unknown"} (
+                      {gallery.createdByLogin || "unknown"})
+                    </p>
+                  </div>
+
+                  <div className="flex flex-col items-start gap-3">
+                    <label className="flex items-center gap-3 text-left">
+                      <input
+                        type="checkbox"
+                        checked={gallery.allowPublicSubmissions}
+                        onChange={(event) =>
+                          handleTogglePublicSubmissions(
+                            gallery.id,
+                            event.target.checked,
+                          )
+                        }
+                        className="h-5 w-5 rounded border-gray-700 bg-gray-950 text-blue-500 focus:ring-blue-500"
+                        disabled={updatingGalleryId === gallery.id}
+                      />
+                      <span className="text-gray-200">
+                        {gallery.allowPublicSubmissions
+                          ? "Open to public submissions"
+                          : "Only organizers can add repos"}
+                      </span>
+                    </label>
+                    {updatingGalleryId === gallery.id && (
+                      <span className="text-xs text-gray-400">Saving…</span>
+                    )}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/gallery/GallerySignInPrompt.tsx
+++ b/src/components/gallery/GallerySignInPrompt.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { signIn } from "next-auth/react";
+
+export default function GallerySignInPrompt() {
+  return (
+    <div className="max-w-lg mx-auto text-center space-y-6 p-10 bg-gray-900/70 border border-gray-800 rounded-2xl shadow-lg">
+      <h1 className="text-3xl font-semibold text-white">
+        Sign in with GitHub to manage galleries
+      </h1>
+      <p className="text-gray-300">
+        Connect your GitHub account to create hackathon galleries and control
+        whether anyone can submit repositories to them.
+      </p>
+      <button
+        onClick={() => signIn("github", { callbackUrl: "/manage/galleries" })}
+        className="inline-flex items-center justify-center gap-2 px-6 py-3 text-lg font-medium text-white bg-gray-800 hover:bg-gray-700 rounded-lg border border-gray-700 transition"
+      >
+        <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+          <path
+            fillRule="evenodd"
+            d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+            clipRule="evenodd"
+          />
+        </svg>
+        Sign in with GitHub
+      </button>
+    </div>
+  );
+}

--- a/src/services/s3/gallery-store.ts
+++ b/src/services/s3/gallery-store.ts
@@ -1,0 +1,103 @@
+import { v4 as uuidv4 } from "uuid";
+
+import { S3ClientBase } from "./s3-client";
+import {
+  GalleryCreateInput,
+  GalleryNotFoundError,
+  GalleryRecord,
+  GalleryUpdateInput,
+  MissingGalleryBucketError,
+} from "@/types/gallery";
+
+const GALLERY_INDEX_KEY = "galleries/index.json";
+
+class GalleryS3Store extends S3ClientBase {
+  constructor(bucketName: string) {
+    super(bucketName);
+  }
+
+  private getGalleryKey(id: string) {
+    return `galleries/${id}.json`;
+  }
+
+  async listGalleries(): Promise<GalleryRecord[]> {
+    const galleries = await this.getObject<GalleryRecord[]>(GALLERY_INDEX_KEY);
+    if (!galleries) {
+      return [];
+    }
+    return galleries;
+  }
+
+  async getGallery(id: string): Promise<GalleryRecord> {
+    const gallery = await this.getObject<GalleryRecord>(
+      this.getGalleryKey(id),
+    );
+
+    if (!gallery) {
+      throw new GalleryNotFoundError(id);
+    }
+
+    return gallery;
+  }
+
+  async createGallery(input: GalleryCreateInput): Promise<GalleryRecord> {
+    const id = uuidv4();
+    const now = new Date().toISOString();
+
+    const gallery: GalleryRecord = {
+      id,
+      name: input.name,
+      description: input.description,
+      createdAt: now,
+      updatedAt: now,
+      createdBy: input.createdBy,
+      createdById: input.createdById,
+      createdByLogin: input.createdByLogin,
+      allowPublicSubmissions: input.allowPublicSubmissions,
+    };
+
+    await this.putObject(this.getGalleryKey(id), gallery);
+
+    const galleries = await this.listGalleries();
+    galleries.push(gallery);
+    await this.putObject(GALLERY_INDEX_KEY, galleries);
+
+    return gallery;
+  }
+
+  async updateGallery(
+    id: string,
+    updates: GalleryUpdateInput,
+  ): Promise<GalleryRecord> {
+    const gallery = await this.getGallery(id);
+    const updatedGallery: GalleryRecord = {
+      ...gallery,
+      ...updates,
+      updatedAt: new Date().toISOString(),
+    };
+
+    await this.putObject(this.getGalleryKey(id), updatedGallery);
+
+    const galleries = await this.listGalleries();
+    const updatedGalleries = galleries.map((existing) =>
+      existing.id === id ? updatedGallery : existing,
+    );
+    await this.putObject(GALLERY_INDEX_KEY, updatedGalleries);
+
+    return updatedGallery;
+  }
+}
+
+let cachedStore: GalleryS3Store | null = null;
+
+export function getGalleryStore(): GalleryS3Store {
+  if (!process.env.S3_GALLERIES_BUCKET) {
+    throw new MissingGalleryBucketError();
+  }
+
+  if (!cachedStore) {
+    cachedStore = new GalleryS3Store(process.env.S3_GALLERIES_BUCKET);
+  }
+
+  return cachedStore;
+}

--- a/src/types/gallery.ts
+++ b/src/types/gallery.ts
@@ -1,17 +1,40 @@
-export interface GalleryRepo {
-  owner: string;
-  repo: string;
-}
-
-export interface Gallery {
+export interface GalleryRecord {
   id: string;
   name: string;
   description?: string;
-  repos: GalleryRepo[];
   createdAt: string;
   updatedAt: string;
+  createdBy: string;
+  createdById: string;
+  createdByLogin: string;
+  allowPublicSubmissions: boolean;
 }
 
-export interface GalleriesState {
-  galleries: Gallery[];
+export interface GalleryCreateInput {
+  name: string;
+  description?: string;
+  allowPublicSubmissions: boolean;
+  createdBy: string;
+  createdById: string;
+  createdByLogin: string;
+}
+
+export interface GalleryUpdateInput {
+  name?: string;
+  description?: string;
+  allowPublicSubmissions?: boolean;
+}
+
+export class GalleryNotFoundError extends Error {
+  constructor(public readonly galleryId: string) {
+    super(`Gallery with id ${galleryId} was not found`);
+    this.name = "GalleryNotFoundError";
+  }
+}
+
+export class MissingGalleryBucketError extends Error {
+  constructor() {
+    super("S3_GALLERIES_BUCKET environment variable is not configured");
+    this.name = "MissingGalleryBucketError";
+  }
 }


### PR DESCRIPTION
## Summary
- re-enable the NextAuth providers in the root layout and document required environment variables
- add S3-backed gallery store with APIs to create and update gallery configuration
- build a GitHub-authenticated gallery management page with UI to create galleries and toggle public submissions

## Testing
- npm run lint *(fails: npm install blocked by 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e1cecdb570832183d76863629dbddf